### PR TITLE
(feat) LIME2-730 Change meal taken symbol and deprecated launchPatientWorkspace

### DIFF
--- a/packages/esm-nutrition-app/src/constants.ts
+++ b/packages/esm-nutrition-app/src/constants.ts
@@ -8,7 +8,7 @@ export const datePickerPlaceHolder = 'dd/mm/yyyy';
 export const dateFormat = 'YYYY-MM-DD';
 export const datePickerFormat = 'd/m/Y';
 
-export const nutritionFormName = 'Nutrition - Feeding Form';
+export const nutritionFormName = 'MSF Nutrition - Feeding Form';
 export const nutritionFormUuid = '9ed6d34e-1415-47a6-82e8-30070f859f38';
 export const nutritionEncounterName = 'Nutrition';
 export const nutritionEncounterUuid = 'efb1ee49-ed60-40f4-aa2e-c45143dc4d49';

--- a/packages/esm-nutrition-app/src/nutrition/nutrition-summary.scss
+++ b/packages/esm-nutrition-app/src/nutrition/nutrition-summary.scss
@@ -44,19 +44,19 @@
     background-color: colors.$red-30 !important;
   }
 
-  &[data-status='+'] {
+  &[data-status='X'] {
     background-color: colors.$orange-20 !important;
   }
 
-  &[data-status='++'] {
+  &[data-status='XX'] {
     background-color: colors.$yellow-20 !important;
   }
 
-  &[data-status='+++'] {
+  &[data-status='XXX'] {
     background-color: colors.$cyan-20 !important;
   }
 
-  &[data-status='++++'] {
+  &[data-status='XXXX'] {
     background-color: colors.$green-30 !important;
   }
 

--- a/packages/esm-nutrition-app/src/utils/helpers.test.ts
+++ b/packages/esm-nutrition-app/src/utils/helpers.test.ts
@@ -1,11 +1,10 @@
-import { launchClinicalViewForm, mealSymbol, getPatientEncounterDates } from './helpers';
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { launchWorkspace, openmrsFetch } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
+import { launchClinicalViewForm, mealSymbol, getPatientEncounterDates } from './helpers';
 import { dateFormat } from '../constants';
 
 jest.mock('@openmrs/esm-patient-common-lib', () => ({
-  launchPatientWorkspace: jest.fn(),
+  launchWorkspace: jest.fn(),
 }));
 
 jest.mock('@openmrs/esm-framework', () => ({
@@ -14,7 +13,7 @@ jest.mock('@openmrs/esm-framework', () => ({
 }));
 
 describe('launchClinicalViewForm', () => {
-  it('should call launchPatientWorkspace with correct parameters', () => {
+  it('should call launchWorkspace with correct parameters', () => {
     const form = { name: 'Test Form' } as any;
     const patientUuid = 'patient-uuid';
     const onFormSave = jest.fn();
@@ -22,7 +21,7 @@ describe('launchClinicalViewForm', () => {
 
     launchClinicalViewForm(form, patientUuid, onFormSave, action);
 
-    expect(launchPatientWorkspace).toHaveBeenCalledWith('patient-form-entry-workspace', {
+    expect(launchWorkspace).toHaveBeenCalledWith('patient-form-entry-workspace', {
       workspaceTitle: form.name,
       mutateForm: onFormSave,
       formInfo: {
@@ -44,10 +43,10 @@ describe('launchClinicalViewForm', () => {
 describe('mealSymbol', () => {
   it.each([
     ['0%', '-'],
-    ['25%', '+'],
-    ['50%', '++'],
-    ['75%', '+++'],
-    ['100%', '++++'],
+    ['25%', 'X'],
+    ['50%', 'XX'],
+    ['75%', 'XXX'],
+    ['100%', 'XXXX'],
     ['unknown', ''],
   ])('should return correct symbol for %s', (input, expected) => {
     expect(mealSymbol(input)).toBe(expected);

--- a/packages/esm-nutrition-app/src/utils/helpers.test.ts
+++ b/packages/esm-nutrition-app/src/utils/helpers.test.ts
@@ -1,10 +1,11 @@
-import { launchWorkspace, openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch } from '@openmrs/esm-framework';
+import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import dayjs from 'dayjs';
 import { launchClinicalViewForm, mealSymbol, getPatientEncounterDates } from './helpers';
 import { dateFormat } from '../constants';
 
 jest.mock('@openmrs/esm-patient-common-lib', () => ({
-  launchWorkspace: jest.fn(),
+  launchPatientWorkspace: jest.fn(),
 }));
 
 jest.mock('@openmrs/esm-framework', () => ({
@@ -13,7 +14,7 @@ jest.mock('@openmrs/esm-framework', () => ({
 }));
 
 describe('launchClinicalViewForm', () => {
-  it('should call launchWorkspace with correct parameters', () => {
+  it('should call launchPatientWorkspace with correct parameters', () => {
     const form = { name: 'Test Form' } as any;
     const patientUuid = 'patient-uuid';
     const onFormSave = jest.fn();
@@ -21,7 +22,7 @@ describe('launchClinicalViewForm', () => {
 
     launchClinicalViewForm(form, patientUuid, onFormSave, action);
 
-    expect(launchWorkspace).toHaveBeenCalledWith('patient-form-entry-workspace', {
+    expect(launchPatientWorkspace).toHaveBeenCalledWith('patient-form-entry-workspace', {
       workspaceTitle: form.name,
       mutateForm: onFormSave,
       formInfo: {

--- a/packages/esm-nutrition-app/src/utils/helpers.ts
+++ b/packages/esm-nutrition-app/src/utils/helpers.ts
@@ -1,5 +1,6 @@
 import { type FormSchema } from '@openmrs/esm-form-engine-lib';
-import { launchWorkspace, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import dayjs from 'dayjs';
 import { dateFormat } from '../constants';
 
@@ -13,7 +14,7 @@ export function launchClinicalViewForm(
   encounterUuid?: string,
   workspaceWindowSize?: 'minimized' | 'maximized',
 ) {
-  launchWorkspace('patient-form-entry-workspace', {
+  launchPatientWorkspace('patient-form-entry-workspace', {
     workspaceTitle: form.name,
     mutateForm: onFormSave,
     formInfo: {

--- a/packages/esm-nutrition-app/src/utils/helpers.ts
+++ b/packages/esm-nutrition-app/src/utils/helpers.ts
@@ -1,6 +1,5 @@
-import { launchPatientWorkspace } from '@openmrs/esm-patient-common-lib';
 import { type FormSchema } from '@openmrs/esm-form-engine-lib';
-import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
+import { launchWorkspace, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import dayjs from 'dayjs';
 import { dateFormat } from '../constants';
 
@@ -14,7 +13,7 @@ export function launchClinicalViewForm(
   encounterUuid?: string,
   workspaceWindowSize?: 'minimized' | 'maximized',
 ) {
-  launchPatientWorkspace('patient-form-entry-workspace', {
+  launchWorkspace('patient-form-entry-workspace', {
     workspaceTitle: form.name,
     mutateForm: onFormSave,
     formInfo: {

--- a/packages/esm-nutrition-app/src/utils/helpers.ts
+++ b/packages/esm-nutrition-app/src/utils/helpers.ts
@@ -37,13 +37,13 @@ export function mealSymbol(value: string): string {
     case '0%':
       return '-';
     case '25%':
-      return '+';
+      return 'X';
     case '50%':
-      return '++';
+      return 'XX';
     case '75%':
-      return '+++';
+      return 'XXX';
     case '100%':
-      return '++++';
+      return 'XXXX';
     default:
       return '';
   }


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
Update the meal taken symbols to match the paper version by replacing `+` with `X`


## Screenshots
<img width="1728" alt="Screenshot 2025-06-04 at 15 30 17" src="https://github.com/user-attachments/assets/c8d324fa-ddca-4407-9f33-1cfb01b6540b" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
