### PR TITLE
(feat) Support obsGroup in nutrition clinical view

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,5 +3,5 @@
 
 set -e  # die on error
 
-npx lint-staged
+yarn lint-staged --no-stash
 yarn turbo run extract-translations

--- a/package.json
+++ b/package.json
@@ -72,8 +72,5 @@
     "packages/**/src/**/*.{ts,tsx}": "eslint --cache --fix --max-warnings 0",
     "*.{css,scss,ts,tsx}": "prettier --cache --write --list-different"
   },
-  "packageManager": "yarn@4.9.2",
-  "dependencies": {
-    "immer": "^10.1.1"
-  }
+  "packageManager": "yarn@4.9.2"
 }

--- a/package.json
+++ b/package.json
@@ -72,5 +72,8 @@
     "packages/**/src/**/*.{ts,tsx}": "eslint --cache --fix --max-warnings 0",
     "*.{css,scss,ts,tsx}": "prettier --cache --write --list-different"
   },
-  "packageManager": "yarn@4.13.0"
+  "packageManager": "yarn@4.9.2",
+  "dependencies": {
+    "immer": "^10.1.1"
+  }
 }

--- a/packages/esm-nutrition-app/src/constants.ts
+++ b/packages/esm-nutrition-app/src/constants.ts
@@ -35,6 +35,8 @@ export const mealRemarkConcept8 = '6a36cb6c-d782-49d5-bcdc-43ac4b1b1c97';
 export const mealRemarkConcept9 = 'ad4760ec-bbbd-48f5-bef1-eeea3cf2afa6';
 export const mealRemarkConcept10 = 'e5d602d4-dc49-4c81-8fa5-e6419af12227';
 
+export const feedingInformationConcept = '9d5a0528-6e3f-482e-9cea-a9931be75244';
+
 export const mealAmountConcepts = [
   mealAmountTaken1,
   mealAmountTaken2,

--- a/packages/esm-nutrition-app/src/hooks/nutrition.resource.ts
+++ b/packages/esm-nutrition-app/src/hooks/nutrition.resource.ts
@@ -17,8 +17,13 @@ export function usePatientNutrition(patientUuid: string) {
     openmrsFetch,
   );
 
+  // Sort by encounterDateTime
+  const nutritionData = data?.data.results.sort((a, b) => {
+    return new Date(a.encounterDatetime).getTime() - new Date(b.encounterDatetime).getTime();
+  });
+
   return {
-    nutritionData: data?.data.results,
+    nutritionData,
     error,
     isLoading,
     mutate,

--- a/packages/esm-nutrition-app/src/nutrition/nutrition-summary.component.tsx
+++ b/packages/esm-nutrition-app/src/nutrition/nutrition-summary.component.tsx
@@ -92,6 +92,10 @@ const NutritionSummary: React.FC<NutritionSummaryProps> = ({ patientUuid }) => {
   const tableRows = useMemo(() => {
     // Build table rows from feeding observations
     const feedingRows: TableRowData[] = [];
+    // Create meal labels
+    const mealLabels = Array.from({ length: 10 }, (_, index) => ({
+      [t('Meal {{number}}', { number: index + 1 })]: {}
+    })).reduce((acc, curr) => ({ ...acc, ...curr }), {});
 
     nutritionData?.forEach((encounter) => {
       const row: TableRowData = {
@@ -100,11 +104,15 @@ const NutritionSummary: React.FC<NutritionSummaryProps> = ({ patientUuid }) => {
           time: false,
           noToday: true,
         }),
+        ...mealLabels,
       };
+
+      mealAmountConcepts.forEach((mealAmountConcept, index) => {
+        let mealNumber = (index % 10) + 1;
+        row[`${t('Meal {{number}}', { number: mealNumber })}`] = getRowData(encounter, mealAmountConcept, index);
+      });
       feedingRows.push(row);
     });
-
-    console.log('feedingRows', feedingRows);
 
     // Build feeding observations from legacy concepts
     const feedingObservations: TableRowData[] = mealAmountConcepts.map((mealAmountConcept, index) => {
@@ -115,9 +123,11 @@ const NutritionSummary: React.FC<NutritionSummaryProps> = ({ patientUuid }) => {
       };
       nutritionData?.forEach((encounter) => {
         row[encounter.uuid] = getRowData(encounter, mealAmountConcept, index);
+        console.log("row[encounter.uuid]", row[encounter.uuid]);
       });
       return row;
     });
+    console.log('feedingRows', feedingRows);
     console.log('feedingObservations', feedingObservations);
 
     // nutritionData?.forEach((encounter) => {

--- a/packages/esm-nutrition-app/src/nutrition/nutrition-summary.component.tsx
+++ b/packages/esm-nutrition-app/src/nutrition/nutrition-summary.component.tsx
@@ -25,7 +25,6 @@ import { usePatientNutrition } from '../hooks/nutrition.resource';
 import { useForm } from '../hooks/form.resource';
 import { feedingInformationConcept, mealAmountConcepts, mealRemarkConcepts, nutritionFormName } from '../constants';
 import styles from './nutrition-summary.scss';
-import { produce } from 'immer';
 
 interface NutritionSummaryProps {
   patientUuid: string;
@@ -38,7 +37,7 @@ interface MealItem {
 
 interface TableRowData {
   id: string;
-  encounterDate: string;
+  meal: string;
   [key: string]: MealItem | string;
 }
 
@@ -66,7 +65,7 @@ const NutritionSummary: React.FC<NutritionSummaryProps> = ({ patientUuid }) => {
     return [
       ...[
         {
-          key: 'encounterDate',
+          key: 'meal',
           header: t('Date'),
         },
       ],
@@ -90,86 +89,72 @@ const NutritionSummary: React.FC<NutritionSummaryProps> = ({ patientUuid }) => {
   };
 
   const tableRows = useMemo(() => {
-    // Build table rows from feeding observations
     const feedingRows: TableRowData[] = [];
-    // Create meal labels
-    const mealLabels = Array.from({ length: 10 }, (_, index) => ({
-      [t('Meal {{number}}', { number: index + 1 })]: {}
-    })).reduce((acc, curr) => ({ ...acc, ...curr }), {});
-
-    nutritionData?.forEach((encounter) => {
+    // Build table rows from feeding observations
+    Array.from({ length: 10 }, (_, mealIndex) => {
       const row: TableRowData = {
-        id: encounter.uuid,
-        encounterDate: formatDate(new Date(encounter.encounterDatetime), {
-          time: false,
-          noToday: true,
-        }),
-        ...mealLabels,
+        id: `meal-${mealIndex + 1}`,
+        meal: `${t('Meal')} ${mealIndex + 1}`,
       };
+      // Build feeding rows
+      nutritionData?.forEach((encounter) => {
+        const feedingInformationObs = encounter.obs.filter((obs) => obs.concept.uuid === feedingInformationConcept);
+        if (feedingInformationObs.length > 0) {
+          feedingInformationObs.forEach((obs) => {
+            if (obs.groupMembers) {
+              for (let i = 0; i < obs.groupMembers.length; i++) {
+                const groupMember = obs.groupMembers[i];
+                const obsRow = { mealTakenSymbol: '', mealRemark: '' };
+                const amountMatch = groupMember?.formFieldPath.match(/rfe-forms-amountTaken(?:_(\d+))?/);
+                const remarkMatch = groupMember?.formFieldPath.match(/rfe-forms-remark(?:_(\d+))?/);
 
-      mealAmountConcepts.forEach((mealAmountConcept, index) => {
-        let mealNumber = (index % 10) + 1;
-        row[`${t('Meal {{number}}', { number: mealNumber })}`] = getRowData(encounter, mealAmountConcept, index);
+                if (!amountMatch && !remarkMatch) continue;
+
+                // Handle case where no amount or remark is found for the first meal
+                if (amountMatch && remarkMatch && mealIndex === 0) {
+                  if (amountMatch[1] === undefined) {
+                    obsRow.mealTakenSymbol = mealSymbol(groupMember.value?.name?.name ?? '');
+                  }
+
+                  if (remarkMatch[1] === undefined) {
+                    obsRow.mealRemark = groupMember.value?.name?.name.charAt(0) ?? '';
+                  }
+
+                  console.log('First meal match', obsRow);
+                  row[encounter.uuid] = obsRow;
+                  continue;
+                } else {
+                  // Skip if neither matches
+                  if (
+                    !(amountMatch && parseInt(amountMatch[1], 10) - 1 === mealIndex) &&
+                    !(remarkMatch && parseInt(remarkMatch[1], 10) - 1 === mealIndex)
+                  ) {
+                    continue;
+                  }
+
+                  // Check for amount match
+                  if (amountMatch && parseInt(amountMatch[1], 10) - 1 === mealIndex) {
+                    obsRow.mealTakenSymbol = mealSymbol(groupMember.value?.name?.name ?? '');
+                  }
+                  // Check for remark match
+                  if (remarkMatch && parseInt(remarkMatch[1], 10) - 1 === mealIndex) {
+                    obsRow.mealRemark = groupMember.value?.name?.name.charAt(0) ?? '';
+                  }
+                }
+                row[encounter.uuid] = obsRow;
+              }
+            }
+          });
+        } else {
+          // Legacy form support
+          row[encounter.uuid] = getRowData(encounter, mealAmountConcepts[mealIndex], mealIndex);
+        }
       });
       feedingRows.push(row);
     });
 
-    // Build feeding observations from legacy concepts
-    const feedingObservations: TableRowData[] = mealAmountConcepts.map((mealAmountConcept, index) => {
-      let mealNumber = (index % 10) + 1;
-      const row: TableRowData = {
-        id: mealAmountConcept,
-        encounterDate: `${t('Meal')} ${mealNumber}`,
-      };
-      nutritionData?.forEach((encounter) => {
-        row[encounter.uuid] = getRowData(encounter, mealAmountConcept, index);
-        console.log("row[encounter.uuid]", row[encounter.uuid]);
-      });
-      return row;
-    });
     console.log('feedingRows', feedingRows);
-    console.log('feedingObservations', feedingObservations);
-
-    // nutritionData?.forEach((encounter) => {
-    //   const feedingInfoObs = encounter.obs.filter((obs) => obs.concept.uuid === feedingInformationConcept);
-    //   if (feedingInfoObs.length > 0) {
-    //     feedingInfoObs.forEach((obs) => {
-    //       obs.groupMembers &&
-    //       obs.groupMembers.forEach((groupMember) => {
-    //         const newFeedingObservations = produce(feedingObservations, draft => {
-    //           const amountMatch = groupMember?.formFieldPath.match(/rfe-forms-amountTaken(?:_(\d+))?/);
-    //           const remarkMatch = groupMember?.formFieldPath.match(/rfe-forms-remark(?:_(\d+))?/);
-
-    //           // Handle mealTakenSymbol
-    //           if (amountMatch) {
-    //             const mealIndex = amountMatch[1] ? Number(amountMatch[1]) - 1 : 0;
-    //             if (draft[mealIndex]) {
-    //               draft[mealIndex][encounter.uuid] = {
-    //                 ...(draft[mealIndex][encounter.uuid] || {}),
-    //                 mealTakenSymbol: mealSymbol(groupMember.value?.name?.name ?? ''),
-    //                 mealRemark: draft[mealIndex][encounter.uuid]?.mealRemark ?? '',
-    //               };
-    //             }
-    //           }
-
-    //           // Handle mealRemark
-    //           if (remarkMatch) {
-    //             const mealIndex = remarkMatch[1] ? Number(remarkMatch[1]) - 1 : 0;
-    //             if (draft[mealIndex]) {
-    //               draft[mealIndex][encounter.uuid] = {
-    //                 ...(draft[mealIndex][encounter.uuid] || {}),
-    //                 mealTakenSymbol: draft[mealIndex][encounter.uuid]?.mealTakenSymbol ?? '',
-    //                 mealRemark: groupMember.value?.name?.name?.charAt(0) ?? '',
-    //               };
-    //             }
-    //           }
-    //         });
-    //       });
-    //     });
-    //   }
-    // });
-
-    return feedingObservations;
+    return feedingRows;
   }, [nutritionData, t]);
 
   if (isLoading) return <DataTableSkeleton role="progressbar" compact={isDesktop} zebra />;

--- a/packages/esm-nutrition-app/src/types/index.ts
+++ b/packages/esm-nutrition-app/src/types/index.ts
@@ -52,9 +52,7 @@ export interface Observation {
       name: string;
     };
   };
-  obsGroup: any;
-  groupMembers?: Array<Observation>;
-  // value: number | string | ObsValue | OpenmrsResource;
+  groupMembers?: Array<ObsGroup>;
   value: any;
   location: OpenmrsResource;
   status: string;
@@ -78,4 +76,47 @@ export interface ObsValueName {
   uuid: string;
   conceptNameType?: string;
   name?: string;
+}
+
+export interface ObsGroup {
+  uuid: string;
+  display: string;
+  concept: OpenmrsResource;
+  person: OpenmrsResource;
+  obsDatetime: string;
+  accessionNumber?: any;
+  obsGroup: OpenmrsResource;
+  valueCodedName?: any;
+  groupMembers?: any;
+  comment?: any;
+  location: OpenmrsResource;
+  order?: any;
+  encounter: OpenmrsResource;
+  voided: boolean;
+  value: {
+    uuid: string;
+    display: string;
+    name: {
+      display: string;
+      uuid: string;
+      name: string;
+    };
+    datatype: OpenmrsResource;
+    conceptClass: OpenmrsResource;
+    set: boolean;
+    version?: any;
+    retired: boolean;
+    names: Array<OpenmrsResource>;
+    descriptions: Array<any>;
+    mappings: Array<any>;
+    answers: Array<any>;
+    setMembers: Array<any>;
+    attributes: Array<any>;
+  };
+  valueModifier?: any;
+  formFieldPath: string;
+  formFieldNamespace: string;
+  status: string;
+  interpretation?: any;
+  referenceRange?: any;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,6 +2289,7 @@ __metadata:
     i18next: "npm:^21.10.0"
     i18next-parser: "npm:^9.0.2"
     identity-obj-proxy: "npm:^3.0.0"
+    immer: "npm:^10.1.1"
     jest: "npm:^29.7.0"
     jest-cli: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
@@ -12282,6 +12283,13 @@ __metadata:
   dependencies:
     "@types/node": "npm:16.9.1"
   checksum: 10c0/4463f8f4c0b6897c2213dfccf08c7731edcaa0ff8e2dab81ce3cafd5bb97d4eaa7bdd64f715d616910cf7b87aba718e4326ed4270b5d13bccc49af24bf5ce1a1
+  languageName: node
+  linkType: hard
+
+"immer@npm:^10.1.1":
+  version: 10.1.1
+  resolution: "immer@npm:10.1.1"
+  checksum: 10c0/b749e10d137ccae91788f41bd57e9387f32ea6d6ea8fd7eb47b23fd7766681575efc7f86ceef7fe24c3bc9d61e38ff5d2f49c2663b2b0c056e280a4510923653
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2289,7 +2289,6 @@ __metadata:
     i18next: "npm:^21.10.0"
     i18next-parser: "npm:^9.0.2"
     identity-obj-proxy: "npm:^3.0.0"
-    immer: "npm:^10.1.1"
     jest: "npm:^29.7.0"
     jest-cli: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
@@ -12283,13 +12282,6 @@ __metadata:
   dependencies:
     "@types/node": "npm:16.9.1"
   checksum: 10c0/4463f8f4c0b6897c2213dfccf08c7731edcaa0ff8e2dab81ce3cafd5bb97d4eaa7bdd64f715d616910cf7b87aba718e4326ed4270b5d13bccc49af24bf5ce1a1
-  languageName: node
-  linkType: hard
-
-"immer@npm:^10.1.1":
-  version: 10.1.1
-  resolution: "immer@npm:10.1.1"
-  checksum: 10c0/b749e10d137ccae91788f41bd57e9387f32ea6d6ea8fd7eb47b23fd7766681575efc7f86ceef7fe24c3bc9d61e38ff5d2f49c2663b2b0c056e280a4510923653
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary
This PR updates the logic for the nutrition summary widget to include changes to the nutrition form. Previously meals were tracked as separate fields but with the recent changes, we've migrated to using an obsGroup field to mitigate concept duplication. 
The changes cater for backward compatibility for already entered data and the breaking change will be that you won't be able to older encounters. 

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
