### PR TITLE
(feat) Manage nutrition encounter cache with globalMutate framework

### DIFF
--- a/packages/esm-nutrition-app/src/nutrition/nutrition-summary.component.tsx
+++ b/packages/esm-nutrition-app/src/nutrition/nutrition-summary.component.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo } from 'react';
-import { formatDate, useLayoutType, isDesktop as desktopLayout } from '@openmrs/esm-framework';
+import { useSWRConfig } from 'swr';
+import { formatDate, restBaseUrl, useLayoutType, isDesktop as desktopLayout } from '@openmrs/esm-framework';
 import { CardHeader, ErrorState } from '@openmrs/esm-patient-common-lib';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
@@ -47,17 +48,27 @@ const NutritionSummary: React.FC<NutritionSummaryProps> = ({ patientUuid }) => {
   const layout = useLayoutType();
   const isTablet = layout === 'tablet';
   const isDesktop = desktopLayout(layout);
+  const { mutate: globalMutate } = useSWRConfig();
   const { form, isLoading: formIsLoading } = useForm(nutritionFormName);
-  const { nutritionData, error, isLoading, mutate } = usePatientNutrition(patientUuid);
+  const { nutritionData, error, isLoading } = usePatientNutrition(patientUuid);
+
+  const handleFormSave = useCallback(
+    () =>
+      globalMutate(
+        (key: unknown) =>
+          typeof key === 'string' && key.includes(`${restBaseUrl}/encounter`) && key.includes(`patient=${patientUuid}`),
+      ),
+    [globalMutate, patientUuid],
+  );
 
   const launchNutritionForm = useCallback(() => {
     if (!form) return;
-    launchClinicalViewForm(form, patientUuid, mutate, 'add');
-  }, [form, patientUuid, mutate]);
+    launchClinicalViewForm(form, patientUuid, handleFormSave, 'add');
+  }, [form, patientUuid, handleFormSave]);
 
   const editNutritionEncounterForm = (encounterUuid: string) => {
     if (!form) return;
-    launchClinicalViewForm(form, patientUuid, mutate, 'edit', encounterUuid);
+    launchClinicalViewForm(form, patientUuid, handleFormSave, 'edit', encounterUuid);
   };
 
   const tableHeaders = useMemo(() => {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).
- [ ] My work includes tests or is validated by existing tests.

## Summary

Use `globalMutate` to automatically invalidate nutrition cache when encounters are updated

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
